### PR TITLE
CCITCARBON-240 Deleting beaker resource failed due to job_url as an additional key in the asset profile

### DIFF
--- a/teflo_linchpin_plugin/helpers/lp_wrapper_helper.py
+++ b/teflo_linchpin_plugin/helpers/lp_wrapper_helper.py
@@ -165,7 +165,7 @@ class LinchpinPinfileBuilder(object):
     @classmethod
     def _build_resource_group_from_asset(cls, asset, pindict):
         resource_grp = {key: val for key, val in asset.profile().items() if key not in
-                        set(getattr(asset, '_fields') + ['tx_id'])}
+                        set(getattr(asset, '_fields') + ['tx_id', 'job_url'])}
         return cls._build_pinfile(asset_name=getattr(asset, 'name'),
                                   workspace=getattr(asset, 'workspace'),
                                   resource_grp=resource_grp,


### PR DESCRIPTION
Updated _build_resource_group_from_asset method to skip job_url key from asset profile